### PR TITLE
Fix temp file handling on Windows

### DIFF
--- a/src/main/com/portalmedia/embarc/parser/dpx/DPXService.java
+++ b/src/main/com/portalmedia/embarc/parser/dpx/DPXService.java
@@ -153,6 +153,7 @@ public class DPXService {
 					fos.write(buffer, 0, length);
 				}
 				is.close();
+				fos.close();
 
 				// Copy the temp file to the final destination
 				final Path tempFile = new File(tempPath).toPath();
@@ -168,10 +169,7 @@ public class DPXService {
 				} catch (final Exception ex) {
 					System.out.println("Error deleting temp file");
 				}
-			}
-			
-			fos.close();
-			
+			}	
 		} catch (final Exception ex) {
 			// Cleanup on error
 			final Path tempFile = new File(tempPath).toPath();


### PR DESCRIPTION
Ensure `fos` is closed before the temp file is copied or deleted as Windows lock open files by default.

This was preventing embARC on Windows to replace the original file after having written the new content in a temporary file.